### PR TITLE
fix: 댓글 조회 및 닉네임 표시 기능 수정

### DIFF
--- a/src/main/java/com/example/NaengTulCook/dto/CommentDTO.java
+++ b/src/main/java/com/example/NaengTulCook/dto/CommentDTO.java
@@ -9,18 +9,18 @@ import com.example.NaengTulCook.entity.Comment;
 public class CommentDTO {
     private int id;
     private int userId;
-    private String username;
+    private String nickname;
     private String content;
 
     public CommentDTO(Comment comment) {
         this.id = comment.getId();
         this.userId = comment.getUser().getId();
-        this.username = comment.getUser().getNickname();  // 닉네임 추가
+        this.nickname = comment.getUser().getNickname();  // 닉네임 추가
         this.content = comment.getContent();
     }
 
     public int getId() { return id; }
     public int getUserId() { return userId; }
-    public String getUsername() { return username; } // 닉네임 반환
+    public String getNickname() { return nickname; } // 닉네임 반환
     public String getContent() { return content; }
 }

--- a/src/main/java/com/example/NaengTulCook/entity/Comment.java
+++ b/src/main/java/com/example/NaengTulCook/entity/Comment.java
@@ -31,4 +31,14 @@ public class Comment {
     public User getUser() { return user; }
     public NeighborExperiencePost getPost() { return post; }
     public String getContent() { return content; }
+
+    @Override
+    public String toString() {
+        return "Comment{" +
+                "id=" + id +
+                ", user=" + (user != null ? user.getNickname() : "null") +
+                ", postId=" + (post != null ? post.getId() : "null") +
+                ", content='" + content + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/com/example/NaengTulCook/repository/CommentRepository.java
+++ b/src/main/java/com/example/NaengTulCook/repository/CommentRepository.java
@@ -2,8 +2,13 @@ package com.example.NaengTulCook.repository;
 
 import com.example.NaengTulCook.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Integer> {
-    List<Comment> findByPostId(int postId);
+//    List<Comment> findByPostId(int postId);
+    @Query("SELECT c FROM Comment c JOIN FETCH c.user WHERE c.post.id = :postId")
+    List<Comment> findByPostIdWithUser(@Param("postId") int postId);
 }

--- a/src/main/java/com/example/NaengTulCook/service/CommentService.java
+++ b/src/main/java/com/example/NaengTulCook/service/CommentService.java
@@ -17,8 +17,13 @@ public class CommentService {
         this.commentRepository = commentRepository;
     }
 
+//    public List<CommentDTO> getCommentsByPostId(int postId) {
+//        List<Comment> comments = commentRepository.findByPostId(postId);
+//        return comments.stream().map(CommentDTO::new).collect(Collectors.toList());
+//    }
     public List<CommentDTO> getCommentsByPostId(int postId) {
-        List<Comment> comments = commentRepository.findByPostId(postId);
-        return comments.stream().map(CommentDTO::new).collect(Collectors.toList());
+        return commentRepository.findByPostIdWithUser(postId).stream()
+                .map(CommentDTO::new)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
변경 사항
- 댓글 조회 시 닉네임이 반환
- 댓글 엔티티에서 userId를 기반으로 닉네임 가져오도록 수정
- API 응답 값에서 닉네임 필드 정상 출력 확인됨

테스트 완료
- Swagger에서 댓글 조회 API 응답 정상 확인
- 기존 게시글 목록 조회 기능에 영향 없음
- GET 구현